### PR TITLE
Compat with rust nightly 22.02

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub fn close() {
 
 ///Stem once
 pub fn stem(input: &str) -> String {
-    let c_input = CString::new(input).unwrap().as_ptr();
-    let c_output = unsafe {m_stem(c_input)};
+    let c_input = CString::new(input).unwrap();
+    let c_output = unsafe {m_stem(c_input.as_ptr())};
     let result = str::from_utf8(unsafe { CStr::from_ptr(c_output) }.to_bytes())
         .unwrap().to_owned();
     unsafe { libc::free(c_output as *mut libc::c_void) };
@@ -35,8 +35,8 @@ pub fn stem(input: &str) -> String {
 ///Stem as many times as something changes
 ///(For example tilings -> tiling -> tile)
 pub fn full_stem(input: &str) -> String {
-    let c_input = CString::new(input).unwrap().as_ptr();
-    let c_output = unsafe {m_full_stem(c_input)};
+    let c_input = CString::new(input).unwrap();
+    let c_output = unsafe {m_full_stem(c_input.as_ptr())};
     let result = str::from_utf8(unsafe { CStr::from_ptr(c_output) }.to_bytes())
         .unwrap().to_owned();
     unsafe { libc::free(c_output as *mut libc::c_void) };


### PR DESCRIPTION
This is the same change that was needed for rust-libxml, without it the llamapun build fails (as it depends on rust-morpha building successfully).
